### PR TITLE
Provide more durability around persistent storage

### DIFF
--- a/pihole.sh
+++ b/pihole.sh
@@ -2,6 +2,9 @@
 
 # https://github.com/pi-hole/docker-pi-hole/blob/master/README.md
 
+# Identify the directory that the script is present in
+DIR=$(dirname "${BASH_SOURCE[0]}")
+
 docker run -d \
     --name pihole \
     -p 53:53/tcp -p 53:53/udp \
@@ -9,8 +12,8 @@ docker run -d \
     -p 443:443 \
     -p 8080:8080 \
     -e TZ="America/Chicago" \
-    -v "$(pwd)/etc-pihole/:/etc/pihole/" \
-    -v "$(pwd)/etc-dnsmasq.d/:/etc/dnsmasq.d/" \
+    -v "$DIR/etc-pihole/:/etc/pihole/" \
+    -v "$DIR/etc-dnsmasq.d/:/etc/dnsmasq.d/" \
     --dns=127.0.0.1 --dns=1.1.1.1 \
     --restart=unless-stopped \
     thenetworkchuck/networkchuck_pihole
@@ -31,4 +34,3 @@ for i in $(seq 1 20); do
         exit 1
     fi
 done;
-© 2020 GitHub, Inc.


### PR DESCRIPTION
Hey Chuck!

I just watched your video on this, and a few things jumped out at me that you may want to consider - and one of which is addressed in this PR!

As an aside, this PR also pulls out the copyright message at the end of the script as I doubt it's applicable (or accurate). It also causes some nasty error output when running the script - best to have it commented out if it were to be included.

### Using `$(pwd)` to identify persistent data locations may provide some unintended results

This is covered in this PR, but the short summary of the concern is that when using `$(pwd)` in a script, you're going to identify the working directory that the script was run from, but *not* where the script is actually located.

For example, let's use the following script:

```
#!/bin/bash

touch $(pwd)/foo

ls -la foo
```

If we run this from our home dir, we'll get a file created under our home dir:

```
maclarel@laptocat:~$ bash foo.sh
-rw-r--r--  1 maclarel  staff  0  3 May 10:00 foo
```

However if we run this script from a different directory, for example `~/test/`, we're going to get the file created under `~/test`:

```
maclarel@laptocat:~/test$ bash ../foo.sh
-rw-r--r--  1 maclarel  staff  0  3 May 10:01 foo
```

At first this output looks the same, but we've actually got the same file created in two different locations. This is applicable in the `pihole.sh` script as with `$(pwd)` defined for your `/etc-pihole` and `/etc-dnsmasq.d` directories you can wind up with a totally new configuration deployed every time you launch the container depending on where you run the script from. 

With the change in this PR, these directories will always be created relative in a location relative to the location of the script. While this is still not as ideal as a permanent location, it should be a bit easier to use for folks unfamiliar with it!

### The password output may be a bit confusing

When starting the container (unless you've modified it specifically), the log output will always include a random password (as it does on the first run). With this said, since you have a persistent `/etc/pihole/` directory defined, it's actually possible to set a password (and other configuration options) that will persist through a container restart.

With this noted, the random password may still be displayed in the startup output *however the user defined password is the one that will actually be usable*.

This is more of a quirk of the pihole docker container, but is something you may want to consider with your own version of it up on Docker Hub!

### You may want to consider using [Docker Compose](https://docs.docker.com/compose/)

Docker Compose simplifies a lot of the configuration, and can provide a more durable experience (like the first point, and this PR aims to provide).

You can actually find an example that I use in "production" (my home network) for PiHole @ https://github.com/maclarel/homelab/blob/master/pihole/docker-compose.yml.

Thanks for the awesome content, and hope this helps in your learning journey! 